### PR TITLE
fix sendAck() error message for Arduino IDE > 1.6

### DIFF
--- a/Helper_Functions.ino
+++ b/Helper_Functions.ino
@@ -16,25 +16,25 @@ void initHardware(){
 	penServo.write(penState);
 }
 
-void inline loadPenPosFromEE() {
+inline void loadPenPosFromEE() {
 	penUpPos = eeprom_read_word(penUpPosEEAddress);
 	penDownPos = eeprom_read_word(penDownPosEEAddress);
 	penState = penUpPos;
 }
 
-void inline storePenUpPosInEE() {
+inline void storePenUpPosInEE() {
 	eeprom_update_word(penUpPosEEAddress, penUpPos);
 }
 
-void inline storePenDownPosInEE() {
+inline void storePenDownPosInEE() {
 	eeprom_update_word(penDownPosEEAddress, penDownPos);
 }
 
-void inline sendAck(){
+inline void sendAck(){
 	Serial.print("OK\r\n");
 }
 
-void inline sendError(){
+inline void sendError(){
 	Serial.print("unknown CMD\r\n");
 }
 


### PR DESCRIPTION
This is a simple bugfix for newer Arduino IDEs than 1.6..
This fixed the error message for "sendAck()" and related.